### PR TITLE
Update GlideImageController.php

### DIFF
--- a/src/Spatie/Glide/Controller/GlideImageController.php
+++ b/src/Spatie/Glide/Controller/GlideImageController.php
@@ -37,7 +37,7 @@ class GlideImageController extends Controller {
 
         $server = $this->setGlideServer($this->setImageSource(), $this->setImageCache(), $api);
 
-        echo $server->outputImage($this->request);
+        return $server->outputImage($this->request);
     }
 
     /**


### PR DESCRIPTION
change echo to return to allow laraval to set the proper mime type for the response. With echo the response mime type is text/html. With return the proper mime type (image/jpg or image/png etc.) is set. See more details here https://github.com/thephpleague/glide/issues/35