### PR TITLE
Storage path referring to app folder

### DIFF
--- a/src/config/laravel-glide.php
+++ b/src/config/laravel-glide.php
@@ -6,7 +6,7 @@ return [
      *
      */
     'source' => [
-        'path' => storage_path('images'),
+        'path' => storage_path('app/images'),
     ],
 
     /*


### PR DESCRIPTION
Ik ben tijden aan het zoeken geweest wat er mis met mijn applicatie/installatie/configuratie, maar jullie verwijzen in de storage path naar de images folder. Dus ```storage/images```, maar wanneer je met ```Storage::put()``` wat opslaat, komt dit in de app-folder van de storage folder te staan. 