### PR TITLE
Add ability to add custom secure url key.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to laravel-glide will be documented in this file.
 
+- Add suport for custom set secure url key 
+
 ## 1.1.0
 - Added support for using multiple Filesystems
 - in some cases the wrong mime-type was return. This is fixed.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ return [
     /*
      * Glide has a feature to sign each generated URL with
      * a key to avoid the visitors of your site to alter the URL
-     * manually
+     * manually.  This may be true, false, or a custom key value.
      */
     'useSecureURLs' => true,
 

--- a/src/Spatie/Glide/Controller/GlideImageController.php
+++ b/src/Spatie/Glide/Controller/GlideImageController.php
@@ -55,7 +55,8 @@ class GlideImageController extends Controller {
         }
 
         if($this->glideConfig['useSecureURLs']) {
-            SignatureFactory::create($this->app['config']->get('app.key'))
+            $key = $this->app->getRegistered("Spatie\\Glide\\GlideServiceProvider")->getSignKey($this->glideConfig);
+            SignatureFactory::create($key)
                 ->validateRequest($this->request);
         }
     }

--- a/src/Spatie/Glide/GlideServiceProvider.php
+++ b/src/Spatie/Glide/GlideServiceProvider.php
@@ -76,6 +76,11 @@ class GlideServiceProvider extends ServiceProvider
             return Config::get('app.key');
         }
 
+        if (!empty($glideConfig['useSecureURLs']) && is_string($glideConfig['useSecureURLs']))
+        {
+            return $glideConfig['useSecureURLs'];
+        }
+
         return null;
     }
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -44,7 +44,7 @@ return [
     /*
      * Glide has a feature to sign each generated URL with
      * a key to avoid the visitors of your site to alter the URL
-     * manually
+     * manually.  This may be true, false, or a custom key value.
      */
     'useSecureURLs' => true
 ];

--- a/tests/unit/SignKeyTest.php
+++ b/tests/unit/SignKeyTest.php
@@ -14,6 +14,7 @@ class SignKeyTest extends \Codeception\TestCase\Test
 
     public function _before()
     {
+        $this->app['config'] = Config::shouldReceive('get')->with('app.key')->andReturn('my-key')->getMock();
         $this->serviceProvider = new GlideServiceProvider($this->app);
     }
 
@@ -52,6 +53,22 @@ class SignKeyTest extends \Codeception\TestCase\Test
         $expectedResult = 'my-key';
 
         $glideConfig['useSecureURLs'] = true;
+
+        Config::shouldReceive('get')->with('app.key')->andReturn($expectedResult);
+
+        $result = $this->serviceProvider->getSignKey($glideConfig);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * Test if custom key is return if useSecureURLs is set to string
+     */
+    public function testTrueCustomSecureURL()
+    {
+        $expectedResult = 'custom-key';
+
+        $glideConfig['useSecureURLs'] = 'custom-key';
 
         Config::shouldReceive('get')->with('app.key')->andReturn($expectedResult);
 


### PR DESCRIPTION
There are some cases where the glide url might need to be generated via a mobile app, or stand alone web application.  In this case, the app.key that's also used to sign passwords might not want to be used, so an alternate key may be with this.

~~Edit: need to fix a couple things first~~