### PR TITLE
Pass path to image so Glide can access EXIF data

### DIFF
--- a/src/Spatie/Glide/GlideImage.php
+++ b/src/Spatie/Glide/GlideImage.php
@@ -98,7 +98,7 @@ class GlideImage
     {
         $glideApi = GlideApiFactory::create();
 
-        $outputImageData = $glideApi->run(Request::create(null, null, $this->modificationParameters), file_get_contents($this->getPathToImage()));
+        $outputImageData = $glideApi->run(Request::create(null, null, $this->modificationParameters), $this->getPathToImage());
 
         file_put_contents($outputFile, $outputImageData);
         


### PR DESCRIPTION
Hey there,

I noticed an issue where the 'auto' orientation manipulation. If the EXIF data isn't available Glide/Intervention doesn't know what the correct orientation is. This is a problem if you have users uploading images taken from mobile devices, as the orientation will be incorrect if taken as "portrait".

If you pass the path to the file instead of using file_get_contents Glide can access the EXIF data and 'auto' set the correct orientation.