### PR TITLE
Fix GlideImageController

### DIFF
--- a/src/Spatie/Glide/Controller/GlideImageController.php
+++ b/src/Spatie/Glide/Controller/GlideImageController.php
@@ -39,7 +39,7 @@ class GlideImageController extends Controller
 
         $server = $this->setGlideServer($this->setImageSource(), $this->setImageCache(), $api);
 
-        return $server->outputImage($this->request);
+        $server->outputImage($this->request);
     }
 
     /**


### PR DESCRIPTION
`$server->outputImage` already sends `StreamedResponse` and returns `$request`, so we can't return it from controller.