### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
         "league/glide": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2",
-        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev"
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev|~3.5.x-dev"
     },
     "autoload": {
         "psr-4": {
@@ -42,3 +42,4 @@
         }
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "~5.3.0|~5.4.0",
+        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev",
         "league/glide": "^1.0"
-
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*",
-        "orchestra/testbench": "~3.3.0|~3.4.0"
+        "phpunit/phpunit": "^6.2",
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev"
     },
     "autoload": {
         "psr-4": {
@@ -29,7 +28,6 @@
             "Spatie\\Glide\\Test\\": "tests"
         }
     },
-    "minimum-stability": "stable",
     "scripts": {
         "test": "vendor/bin/phpunit"
     },


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-glide/phpunit.xml.dist

..E.                                                                4 / 4 (100%)

Time: 1.54 seconds, Memory: 14.00MB

There was 1 error:

1) Spatie\Glide\Test\Integration\GlideImageTest::it_will_throw_an_exception_if_the_source_file_does_not_exist
Error: Call to undefined method Spatie\Glide\Test\Integration\GlideImageTest::setExpectedException()

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-glide/tests/Integration/GlideImageTest.php:36

ERRORS!
Tests: 4, Assertions: 6, Errors: 1.

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

So there are some errors, but it could work!